### PR TITLE
Add sprite atlases to output

### DIFF
--- a/AssetGUI/MainProgram.cs
+++ b/AssetGUI/MainProgram.cs
@@ -25,6 +25,8 @@ namespace AssetGUI
         public bool exportShader { get; set; }
         public bool exportMeshes { get; set; }
         public bool exportAnimator { get; set; }
+        public bool exportMonoBehaviours { get; set; }
+        public bool exportSpriteAtlases { get; set; }
 
         public string AssetDownloadUrl
         {
@@ -160,7 +162,7 @@ namespace AssetGUI
             {
                 var prefix = assetName.Split('_')[0];
                 var downloadedFile = DownloadAssetBundle(assetName);
-                fileHelper.UnpackBundle(downloadedFile, $"{targetFolder}/{prefix}", assetName, this.exportShader, this.exportMeshes, this.exportAnimator);
+                fileHelper.UnpackBundle(downloadedFile, $"{targetFolder}/{prefix}", assetName, this.exportShader, this.exportMeshes, this.exportAnimator, this.exportMonoBehaviours, this.exportSpriteAtlases);
                 Console.WriteLine($"Done exportSingleFile!");
             }
             catch (Exception ex)

--- a/AssetGUI/MainWindow.xaml
+++ b/AssetGUI/MainWindow.xaml
@@ -11,11 +11,11 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid x:Name="mainGrid" Grid.Row="1" VerticalAlignment="Center" HorizontalAlignment="Center">
+    <Grid x:Name="mainGrid" Grid.Row="1" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="20">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="125" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="100" />
+            <ColumnDefinition Width="350" />
+            <ColumnDefinition Width="125" />
             <ColumnDefinition Width="130" />
         </Grid.ColumnDefinitions>
 
@@ -42,25 +42,25 @@
         <TextBlock x:Name="tblHeaderText" Text="This Program will download Asset files from the swgoh Server" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3"></TextBlock>
         
         <TextBlock x:Name="tblAssetOS" Text="AssetOS:" Grid.Row="1" Grid.Column="0"></TextBlock>
-        <ComboBox x:Name="cbAssetOs" Grid.Row="1" Grid.Column="1" MinWidth="400" ItemsSource="{x:Bind AssetOSs}" SelectedItem="{x:Bind SelectedAssetOS, Mode=TwoWay}"></ComboBox>
+        <ComboBox x:Name="cbAssetOs" Grid.Row="1" Grid.Column="1" MinWidth="350" ItemsSource="{x:Bind AssetOSs}" SelectedItem="{x:Bind SelectedAssetOS, Mode=TwoWay}" MaxWidth="350" Width="350"></ComboBox>
 
         <TextBlock x:Name="tblVersion" Text="Assetversion:" Grid.Row="2" Grid.Column="0"></TextBlock>
-        <TextBox x:Name="tbVersion" Text="3512" Grid.Row="2" Grid.Column="1"></TextBox>
+        <TextBox x:Name="tbVersion" Text="3512" Grid.Row="2" Grid.Column="1" HorizontalAlignment="Left" MaxWidth="350" Width="350"></TextBox>
         <Button x:Name="btRefreshVersion" Grid.Row="2" Grid.Column="2" Click="btRefreshVersion_Click">
             <SymbolIcon Symbol="Refresh"/>
         </Button>
         <Button x:Name="btGetManifest" Grid.Row="2" Grid.Column="3" Content="Get Asset List" Click="btGetManifest_Click"/>
 
         <TextBlock x:Name="tblExportPath" Text="Export Path:" Grid.Row="4" Grid.Column="0"></TextBlock>
-        <TextBox x:Name="tbExportPath" Text="" Grid.Row="4" Grid.Column="1"></TextBox>
+        <TextBox x:Name="tbExportPath" Text="" Grid.Row="4" Grid.Column="1" HorizontalAlignment="Left" MaxWidth="350" Width="350"></TextBox>
         <Button x:Name="btSetExportPath" Grid.Row="4" Grid.Column="3" Content="Set Path" Click="btSetExportPath_Click"/>
 
         <TextBlock x:Name="tblDownloadSingle" Text="Single:" Grid.Row="6" Grid.Column="0"></TextBlock>
-        <ComboBox x:Name="cbDownloadSingle" Grid.Row="6" Grid.Column="1" MinWidth="400" ItemsSource="{x:Bind DownloadableAssets}" SelectedItem="{x:Bind SelectedDownloadableAsset, Mode=TwoWay}"></ComboBox>
+        <ComboBox x:Name="cbDownloadSingle" Grid.Row="6" Grid.Column="1" MinWidth="350" ItemsSource="{x:Bind DownloadableAssets}" SelectedItem="{x:Bind SelectedDownloadableAsset, Mode=TwoWay}" MaxWidth="350" Width="350"></ComboBox>
         <Button x:Name="btDownloadSingle" Grid.Row="6" Grid.Column="3" Content="Download Single" Click="btDownloadSingle_Click"/>
 
         <TextBlock x:Name="tblDownloadPrefix" Text="Prefix:" Grid.Row="8" Grid.Column="0"></TextBlock>
-        <ComboBox x:Name="cbDownloadPrefix" Grid.Row="8" Grid.Column="1" MinWidth="400" ItemsSource="{x:Bind prefixes}" SelectedItem="{x:Bind SelectedPrefix, Mode=TwoWay}"></ComboBox>
+        <ComboBox x:Name="cbDownloadPrefix" Grid.Row="8" Grid.Column="1" MinWidth="350" ItemsSource="{x:Bind prefixes}" SelectedItem="{x:Bind SelectedPrefix, Mode=TwoWay}" MaxWidth="350" Width="350"></ComboBox>
         <Button x:Name="btDownloadPrefix" Grid.Row="8" Grid.Column="3" Content="Download Prefix" Click="btDownloadPrefix_Click"/>
 
         <TextBlock x:Name="tblDownloadAll" Text="Download All:" Grid.Row="10" Grid.Column="0"></TextBlock>
@@ -74,9 +74,17 @@
         <TextBlock x:Name="tblDownloadAudio" Text="Download Audio:" Grid.Row="14" Grid.Column="0"></TextBlock>
         <Button x:Name="btDownloadAudio" Grid.Row="14" Grid.Column="3" Content="Download Audio" Click="btDownloadAudio_Click"/>
 
-        <CheckBox x:Name="cbShader" Grid.Row="16" Grid.Column="0" Content="Shader" Checked="cbShader_Checked" Unchecked="cbShader_Checked"/>
-        <CheckBox x:Name="cbMeshes" Grid.Row="16" Grid.Column="1" Content="Meshes" Checked="cbMeshes_Checked" Unchecked="cbMeshes_Checked"/>
-        <CheckBox x:Name="cbAnimator" Grid.Row="16" Grid.Column="2" Content="Animator" Checked="cbAnimator_Checked" Unchecked="cbAnimator_Checked"/>
+        <ItemsControl Grid.Row="16" Grid.ColumnSpan="4">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <Grid ColumnDefinitions="150,150,150,150"/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <CheckBox x:Name="cbShader" Grid.Row="16" Grid.Column="0" Content="Shader" Checked="cbShader_Checked" Unchecked="cbShader_Checked"/>
+            <CheckBox x:Name="cbMeshes" Grid.Row="16" Grid.Column="1" Content="Meshes" Checked="cbMeshes_Checked" Unchecked="cbMeshes_Checked"/>
+            <CheckBox x:Name="cbAnimator" Grid.Row="16" Grid.Column="2" Content="Animator" Checked="cbAnimator_Checked" Unchecked="cbAnimator_Checked"/>
+            <CheckBox x:Name="cbSpriteAtlases" Grid.Row="16" Grid.Column="3" Content="Sprite Atlases" Checked="cbSpriteAtlases_Checked" Unchecked="cbSpriteAtlases_Checked"/>
+        </ItemsControl>
         
     </Grid>
     

--- a/AssetGUI/MainWindow.xaml.cs
+++ b/AssetGUI/MainWindow.xaml.cs
@@ -59,8 +59,11 @@ namespace AssetGUI
             //Console.SetOut();
 
             this.mainProgram = new MainProgram();
-            SetWindowSize(800, 500);
+            SetWindowSize(1000, 410);
             setVisibilityOfSecondaryRows(false);
+            this.Title = "AssetGUI";
+
+            this.cbSpriteAtlases.IsChecked = true;
 
             this.AssetOSs = new List<AssetOS>() { AssetOS.Windows, AssetOS.Android, AssetOS.iOS };
             this.SelectedAssetOS = AssetOS.Windows;
@@ -171,7 +174,7 @@ namespace AssetGUI
             prefixes.AddRange(mainProgram.GetPrefixesFromManifest());
             SelectedPrefix = prefixes.FirstOrDefault();
 
-            SetWindowSize(800, 500);
+            SetWindowSize(1000, 650);
             setVisibilityOfSecondaryRows(true);
         }
 
@@ -255,6 +258,11 @@ namespace AssetGUI
         private void cbAnimator_Checked(object sender, RoutedEventArgs e)
         {
             this.mainProgram.exportAnimator = this.cbAnimator.IsChecked.Value;
+        }
+
+        private void cbSpriteAtlases_Checked(object sender, RoutedEventArgs e)
+        {
+            this.mainProgram.exportSpriteAtlases = this.cbSpriteAtlases.IsChecked.Value;
         }
     }
 }

--- a/AssetGetterTools/helpers/Filehelper.cs
+++ b/AssetGetterTools/helpers/Filehelper.cs
@@ -31,6 +31,7 @@ namespace AssetGetterTools
 
             var assetManager = new AssetsManager();
             exportableAssets.Clear();
+            exportableSprites.Clear();
 
             assetManager.LoadFilesAndFolders(pathes.ToArray());
 

--- a/AssetGetterTools/helpers/SpriteAtlasParser.cs
+++ b/AssetGetterTools/helpers/SpriteAtlasParser.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AssetGetterTools.models;
+
+namespace AssetGetterTools.helpers
+{
+    public static class SpriteAtlasParser
+    {
+        public static Atlas ParseAtlas(byte[] data)
+        {
+            var atlas = new Atlas();
+
+            using (var ms = new MemoryStream(data))
+            using (var br = new BinaryReader(ms))
+            {
+                // PPtr<GameObject>
+                int fileID_GameObject = br.ReadInt32();
+                long pathID_GameObject = br.ReadInt64();
+
+                // m_Enabled
+                bool mEnabled = br.ReadBoolean();
+                Align4(br);
+
+                // PPtr<Script>
+                int fileID_Script = br.ReadInt32();
+                long pathID_Script = br.ReadInt64();
+
+                // m_Name
+                int nameLen = br.ReadInt32();
+                string atlasName = Encoding.UTF8.GetString(br.ReadBytes(nameLen));
+                Align4(br);
+                atlas.Name = atlasName;
+
+                // PPtr<Material>
+                int fileID_Material = br.ReadInt32();
+                long pathID_Material = br.ReadInt64();
+
+                int count = br.ReadInt32();
+                for (int i = 0; i < count; i++)
+                {
+                    SpriteItem sprite = new SpriteItem();
+
+                    int spriteNameLen = br.ReadInt32();
+                    sprite.Name = Encoding.UTF8.GetString(br.ReadBytes(spriteNameLen));
+                    Align4(br);
+
+                    sprite.X = br.ReadInt32();
+                    sprite.Y = br.ReadInt32();
+                    sprite.Width = br.ReadInt32();
+                    sprite.Height = br.ReadInt32();
+                    sprite.BorderLeft = br.ReadInt32();
+                    sprite.BorderRight = br.ReadInt32();
+                    sprite.BorderTop = br.ReadInt32();
+                    sprite.BorderBottom = br.ReadInt32();
+                    sprite.PaddingLeft = br.ReadInt32();
+                    sprite.PaddingRight = br.ReadInt32();
+                    sprite.PaddingTop = br.ReadInt32();
+                    sprite.PaddingBottom = br.ReadInt32();
+                    sprite.MirrorHorizontal = br.ReadBoolean();
+                    Align4(br);
+                    sprite.MirrorVertical = br.ReadBoolean();
+                    Align4(br);
+                    sprite.MirrorRotate = br.ReadBoolean();
+                    Align4(br);
+
+                    atlas.Sprites.Add(sprite);
+                }
+            }
+
+            return atlas;
+        }
+
+        static void Align4(BinaryReader br)
+        {
+            long pos = br.BaseStream.Position;
+            long mod = pos % 4;
+            if (mod != 0)
+                br.BaseStream.Position += (4 - mod);
+        }
+    }
+    }
+

--- a/AssetGetterTools/helpers/SpriteCutter.cs
+++ b/AssetGetterTools/helpers/SpriteCutter.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AssetGetterTools.models;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+namespace AssetGetterTools.helpers
+{
+    public class SpriteCutter
+    {
+        public static void CutSprites(Atlas atlas, string exportPath)
+        {
+            if (TryExportFile(exportPath, atlas.Name, ".png", out var loadFullPath)) // Image doesn't exist
+            {
+                Console.WriteLine($"Could not export sprite atlas: {atlas.Name}. You can ignore this");
+                return;
+            }
+
+            Image<Rgba32> SpriteImage = Image.Load<Rgba32>(loadFullPath);
+            foreach (var sprite in atlas.Sprites)
+            {
+                Image<Rgba32> spriteOutput = SpriteImage.Clone(img => img.Crop(new Rectangle(sprite.X, sprite.Y, sprite.Width, sprite.Height)));
+                if (!TryExportFile(Path.Combine(exportPath, "sprites", atlas.Name), sprite.Name, ".png", out var exportFullPath))
+                    continue;
+                spriteOutput.Save(exportFullPath);
+            }
+        }
+
+        private static bool TryExportFile(string dir, string itemName, string extension, out string fullPath)
+        {
+            var fileName = FixFileName(itemName);
+            fullPath = Path.Combine(dir, fileName + extension);
+            if (!File.Exists(fullPath))
+            {
+                Directory.CreateDirectory(dir);
+                return true;
+            }
+            return false;
+        }
+
+        private static string FixFileName(string str)
+        {
+            if (str.Length >= 260) return Path.GetRandomFileName();
+            return Path.GetInvalidFileNameChars().Aggregate(str, (current, c) => current.Replace(c, '_'));
+        }
+    }
+}

--- a/AssetGetterTools/models/SpriteItem.cs
+++ b/AssetGetterTools/models/SpriteItem.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AssetGetterTools.models
+{
+    public class SpriteItem
+    {
+        public string Name;
+        public int X;
+        public int Y;
+        public int Width;
+        public int Height;
+        public int BorderLeft;
+        public int BorderRight;
+        public int BorderTop;
+        public int BorderBottom;
+        public int PaddingLeft;
+        public int PaddingRight;
+        public int PaddingTop;
+        public int PaddingBottom;
+        public bool MirrorHorizontal;
+        public bool MirrorVertical;
+        public bool MirrorRotate;
+    }
+
+    public class Atlas
+    {
+        public string Name;
+        public List<SpriteItem> Sprites = new List<SpriteItem>();
+    }
+}

--- a/SwgohAssetGetterConsole/MainProgram.cs
+++ b/SwgohAssetGetterConsole/MainProgram.cs
@@ -18,6 +18,7 @@ namespace SwgohAssetGetterConsole
         public string AssetVersion { get; set; }
 
         public bool exportMeshes { get; set; }
+        public bool exportSpriteAtlases { get; set; }
         public AssetOS assetOS { get; set; }
 
         public string AssetDownloadUrl
@@ -160,7 +161,7 @@ namespace SwgohAssetGetterConsole
             {
                 var prefix = assetName.Split('_')[0];
                 var downloadedFile = DownloadAssetBundle(assetName);
-                fileHelper.UnpackBundle(downloadedFile, $"{targetFolder}/{prefix}", assetName, false, this.exportMeshes);
+                fileHelper.UnpackBundle(downloadedFile, $"{targetFolder}/{prefix}", assetName, false, this.exportMeshes, false, false, this.exportSpriteAtlases);
             }
             catch (Exception ex)
             {

--- a/SwgohAssetGetterConsole/consoleStart.cs
+++ b/SwgohAssetGetterConsole/consoleStart.cs
@@ -37,10 +37,10 @@ namespace SwgohAssetGetterConsole
                 ProcessAdditionalParameters(args, mainProgram);
 
                 var argToProcess = args[0];
-                switch(argToProcess)
+                switch(argToProcess.ToLowerInvariant())
                 {
-                    case "-DM":
-                    case "-diffManifest":
+                    case "-dm":
+                    case "-diffmanifest":
                         Console.WriteLine($"Start Comparing Manifests");
                         var firstAsset = args[1];
                         var secondAsset = args[2];
@@ -53,17 +53,17 @@ namespace SwgohAssetGetterConsole
 
                         Console.WriteLine($"Done Comparing Manifests");
                         break;
-                    case "-downloadManifest":
+                    case "-downloadmanifest":
                         Console.WriteLine($"Downloading Manifest...");
                         mainProgram.DownloadManifest();
                         Console.WriteLine($"Manifest downloaded!");
                         break;
-                    case "-getAssetNames":
+                    case "-getassetnames":
                         Console.WriteLine($"Getting asset Names...");
                         mainProgram.SaveAssetNamesToFile();
                         Console.WriteLine($"Assetnames file created...");
                         break;
-                    case "-getAssetPrefixes":
+                    case "-getassetprefixes":
                         Console.WriteLine($"Getting asset Prefixes...");
                         mainProgram.SavePrefixesToFile();
                         Console.WriteLine($"Prefixes file created...");
@@ -83,7 +83,7 @@ namespace SwgohAssetGetterConsole
                         {
                             var diffTypeArgument = args[2];
 
-                            switch (diffTypeArgument)
+                            switch (diffTypeArgument.ToLowerInvariant())
                             {
                                 case "all":
                                     Console.WriteLine($"Setting Difftype to {nameof(DiffType.All)}");
@@ -162,11 +162,9 @@ namespace SwgohAssetGetterConsole
                         var currentParameter = args[i+1];
                         var redownloadManifestAutomation = false;
 
-                        switch (currentArg)
+                        switch (currentArg.ToLowerInvariant())
                         {
-                            case "-Version":
                             case "-version":
-                            case "-V":
                             case "-v":
                                 if(mainProgram.AssetVersion != currentParameter)
                                 {
@@ -175,24 +173,25 @@ namespace SwgohAssetGetterConsole
                                 mainProgram.AssetVersion = currentParameter;
                                 Console.WriteLine($"Assetversion setted to: {mainProgram.AssetVersion}");
                                 break;
-                            case "-Target":
                             case "-target":
-                            case "-T":
                             case "-t":
                                 mainProgram.targetFolder = currentParameter;
                                 Console.WriteLine($"TargetFolder setted to: {mainProgram.targetFolder}");
                                 break;
-                            case "-Workingfolder":
                             case "-workingfolder":
-                            case "-W":
                             case "-w":
                                 mainProgram.workingFolder = currentParameter;
                                 Console.WriteLine($"Workingfolder setted to: {mainProgram.workingFolder}");
                                 break;
-                            case "-ExportMeshes":
-                            case "-eM":
+                            case "-exportmeshes":
+                            case "-em":
                                 mainProgram.exportMeshes = (currentParameter == "true" || currentParameter == "t");
                                 Console.WriteLine($"exportMeshes setted to: {mainProgram.exportMeshes}");
+                                break;
+                            case "-exportsprites":
+                            case "-es":
+                                mainProgram.exportSpriteAtlases = (currentParameter == "true" || currentParameter == "t");
+                                Console.WriteLine("exportSpriteAtlases set to: " + mainProgram.exportSpriteAtlases);
                                 break;
                             default:
                                 Console.WriteLine($"Unknown Argument '{currentArg}'");


### PR DESCRIPTION
## New Features:
* Sprite Exports

## Changes:
* The CLI version is now case and culture insensitive for flags
  * This is because in testing I was getting inconsistent results on flags due to culture
* The GUI version uses fixed grid sizes
  * This is to support the new button added for sprite exports

### Sprite Exports
Sprite atlases are used to send one image with many sprites on it to improve efficiency. You however need a cut sheet. This PR adds the cut sheet to the output and cuts sprites for you.

It will search for a sprite atlas and then after all regular images are extracted it will export the sprite atlas in `prefixed_folder/sprites/atlas_name/atlas_name.json` (example: shared_uicontainer contains misc_atlas which will output to `root/OutPut/sprites/misc_atlas/misc_atlas.json`) It will also output any images as well if possible. (example: misc_atlas contains arrow_tab, which will be at `root/OutPut/sprites/misc_atlas/arrow_tab.png`) .

These features are only available for GUI and CLI, and must be enabled. GUI has a checkbox and CLI has `-ExportSprites` or `-eS`.

To test the new sprite atlas feature you must select a bundle that contains a sprite atlas. The one with the most is `shared_uicontainer`. All export methods that can export an image (All, prefix, diff, single) support sprite exports.

### Technical details:
The sprite exports require the atlas.png to be present and of the same name. If the image cannot be found it will log 
`Could not export sprite atlas: {atlas name}. You can ignore this`
This will still output a .json which can be used to find the actual atlas (most of the time this will be standard_atlas)

Integrating with the API is not completely possible currently. Many of the bundles that contain sprites contain multiple images and the API currently can only respond with one image.