### PR TITLE
feat: Add /Asset/zip

### DIFF
--- a/AssetWebApi/Controllers/AssetController.cs
+++ b/AssetWebApi/Controllers/AssetController.cs
@@ -1,5 +1,7 @@
 using AssetGetterTools.models;
 using Microsoft.AspNetCore.Mvc;
+using System.IO.Compression;
+using AssetWebApi.Helpers;
 
 namespace AssetWebApi.Controllers
 {
@@ -73,6 +75,49 @@ namespace AssetWebApi.Controllers
             var singleFilePath = mainProgram.getSingleTextureIfExists(assetName, forceReDownload);
             var fileContent = System.IO.File.ReadAllBytes(singleFilePath);
             return File(fileContent, "application/octet-stream", Path.GetFileName(singleFilePath));
+        }
+
+        /// <summary>
+        /// Gets a bundle of Textures and returns them as a zip. May contain multiple.
+        /// </summary>
+        /// <param name="assetName">the name of the asset to download</param>
+        /// <param name="version">the assetversion. you can get it via Metadata in comlink.</param>
+        /// <param name="forceReDownload">Optional parameter (default = false). true Forces a re-download from the CG Server. Otherwise it uses the cache if possible.</param>
+        /// <param name="exportSpriteAtlases">Optional parameter (default = false). true will return sprite atlases</param>
+        /// <returns></returns>
+        [HttpGet("zip")]
+        public FileStreamResult GetZip(string assetName, int version, bool forceReDownload = false, bool exportSpriteAtlases = false, AssetOS assetOS = AssetOS.Windows)
+        {
+            var defaultSettings = DefaultSettings.GetDefaultSettings() ?? 
+                throw new Exception("Could not load DefaultSettings. settings.json may not exist");
+            using (var temp = new TempFolder(defaultSettings.defaultOutputDirectory))
+            {
+                var mainProgram = new MainProgram(assetOS);
+                mainProgram.AssetVersion = version.ToString();
+                mainProgram.targetFolder = temp.Folder;
+                mainProgram.exportSpriteAtlases = exportSpriteAtlases;
+                mainProgram.getSingleTextureIfExists(assetName, forceReDownload);
+
+                var responseStream = new MemoryStream();
+                using (var archive = new ZipArchive(responseStream, ZipArchiveMode.Create, true))
+                {
+                    var files = Directory.GetFiles(temp.Folder, "*", SearchOption.AllDirectories);
+                    foreach (var filePath in files)
+                    {
+                        var fileName = Path.GetRelativePath(temp.Folder, filePath);
+                        var archiveFile = archive.CreateEntry(fileName, CompressionLevel.Optimal);
+
+                        using (var archiveFileStream = archiveFile.Open())
+                        using (var fileStream = System.IO.File.OpenRead(filePath))
+                        {
+                            fileStream.CopyTo(archiveFileStream);
+                        }
+                    }
+                }
+
+                responseStream.Position = 0;
+                return File(responseStream, "application/zip", $"{assetName}.zip");
+            }
         }
     }
 }

--- a/AssetWebApi/Helpers/TempFolder.cs
+++ b/AssetWebApi/Helpers/TempFolder.cs
@@ -1,0 +1,40 @@
+namespace AssetWebApi.Helpers
+{
+    public class TempFolder : IDisposable
+    {
+        public string Folder { get; }
+
+        public TempFolder(string workingDirectory)
+        {
+            string folder;
+            do // Loop to handle edge cases where file names could match others. No an AI did not suggest this.
+            {
+                folder = Path.Combine(workingDirectory, Path.GetRandomFileName());
+            } while (Directory.Exists(folder));
+
+            Folder = folder;
+            Directory.CreateDirectory(Folder);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+        protected virtual void Dispose(bool disposing)
+        {
+            try
+            {
+                if (Directory.Exists(Folder) && disposing)
+                {
+                    Directory.Delete(Folder, true);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Could not delete temp folder {Folder} for reason {ex.Message}");
+            }
+
+        }
+    }
+}

--- a/AssetWebApi/MainProgram.cs
+++ b/AssetWebApi/MainProgram.cs
@@ -18,6 +18,7 @@ namespace AssetWebApi
         public string AssetVersion { get; set; }
 
         public bool exportMeshes { get; set; }
+        public bool exportSpriteAtlases { get; set; }
 
         public string AssetDownloadUrl
         {
@@ -169,7 +170,7 @@ namespace AssetWebApi
                 else
                 {
                     var downloadedFile = DownloadAssetBundle(assetName);
-                    fileHelper.UnpackBundle(downloadedFile, $"{targetFolder}/{prefix}", assetName, false, this.exportMeshes);
+                    fileHelper.UnpackBundle(downloadedFile, $"{targetFolder}/{prefix}", assetName, exportShader: false, this.exportMeshes, exportAnimator: false, exportMonoBehavior: false, this.exportSpriteAtlases);
                     return fullFilePath;
                 }
 


### PR DESCRIPTION
This PR adds the `/Asset/zip` endpoint to AssetWebApi.
All input queries are identical to `/Asset/single` (So version, assetName, forceReDownload, assetOS) as well as the addition of exportSpriteAtlases.
The response is a .zip file that contains all assets in the selected bundle, instead of just one named the same as the bundle.
Inside .zip the files are identical to how they are from the GUI or CLI.

The reason this is useful is for bundles like `shared_uicontainer` where `/Asset/single` returns an error because no texture in the bundle matches the name of the bundle. It also enables the export of all assets rather than just one, enabling sprite exports.

The collecting of assets not matching the names of the ones in the bundle is by extracting everything to a temp folder, then zipping the temp folder before deleting it.